### PR TITLE
feat: add Kubernetes-standard health endpoints to all services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,17 +227,19 @@ k8s-forward:
 	@echo ""
 	@echo "Services will be available at:"
 	@echo "  • API:        http://localhost:8080"
+	@echo "  • Worker:     http://localhost:8181 (metrics, health)"
+	@echo "  • Controller: http://localhost:8282 (metrics, health)"
 	@echo "  • Grafana:    http://localhost:3000 (admin/admin)"
 	@echo "  • Prometheus: http://localhost:9090"
-	@echo "  • Controller: http://localhost:8081/metrics"
 	@echo ""
 	@echo "Press Ctrl+C to stop all port forwards"
 	@echo ""
 	@trap 'kill 0' EXIT; \
 	kubectl port-forward -n $(K8S_NAMESPACE) svc/api 8080:8080 & \
+	kubectl port-forward -n $(K8S_NAMESPACE) deployment/worker 8181:8080 & \
+	kubectl port-forward -n $(K8S_NAMESPACE) svc/controller-metrics-service 8282:8080 & \
 	kubectl port-forward -n monitoring svc/grafana 3000:3000 & \
 	kubectl port-forward -n monitoring svc/prometheus 9090:9090 & \
-	kubectl port-forward -n $(K8S_NAMESPACE) svc/controller-metrics-service 8081:8081 & \
 	wait
 
 k8s-status:

--- a/claude.md
+++ b/claude.md
@@ -130,7 +130,9 @@ All services must expose standardized health endpoints following Kubernetes conv
   - Follows Kubernetes ecosystem naming convention
 
 **Implementation:**
-- Expose health endpoints on the same port as metrics or main HTTP server
+- All services use **port 8080** for all endpoints (metrics, health, API)
+- Single HTTP server per service serves all endpoints (metrics, health, business logic)
+- Expose health endpoints on the same port as metrics endpoint
 - Use context-aware health checks with reasonable timeouts
 - Log health check failures for debugging
 - Keep liveness checks simple to avoid false positives
@@ -138,16 +140,20 @@ All services must expose standardized health endpoints following Kubernetes conv
 
 **Deployment Configuration:**
 ```yaml
+ports:
+- name: http
+  containerPort: 8080
+  protocol: TCP
 livenessProbe:
   httpGet:
     path: /livez
-    port: <service-port>
+    port: 8080
   initialDelaySeconds: 15-30
   periodSeconds: 10-20
 readinessProbe:
   httpGet:
     path: /readyz
-    port: <service-port>
+    port: 8080
   initialDelaySeconds: 5
   periodSeconds: 5-10
 ```
@@ -402,10 +408,11 @@ kubectl apply -f deployments/base/monitoring/monitoring.yaml
 # Port forward all services (recommended)
 make k8s-forward
 # This forwards:
-#   - API:        http://localhost:8080
+#   - API:        http://localhost:8080 (metrics, health)
+#   - Worker:     http://localhost:8181 (metrics, health)
+#   - Controller: http://localhost:8282 (metrics, health)
 #   - Grafana:    http://localhost:3000 (admin/admin)
 #   - Prometheus: http://localhost:9090
-#   - Controller: http://localhost:8081/metrics
 
 # Check monitoring status
 make monitoring-status

--- a/claude.md
+++ b/claude.md
@@ -114,6 +114,48 @@
 - Set proper RBAC permissions (ServiceAccount, Role, RoleBinding)
 - Implement health and readiness probes for controller pods
 
+### Health Endpoints
+All services must expose standardized health endpoints following Kubernetes conventions:
+
+**Required Endpoints:**
+- `/livez` - Liveness probe: Basic check that the process is running and not deadlocked
+  - Returns HTTP 200 OK if alive
+  - Simple check, no external dependencies
+  - Used by Kubernetes to restart unhealthy pods
+- `/readyz` - Readiness probe: Check if service can accept traffic
+  - Returns HTTP 200 OK if ready, 503 Service Unavailable if not ready
+  - Must check all critical dependencies (database, Redis, etc.)
+  - Used by Kubernetes to route traffic only to ready pods
+- `/healthz` - General health check (typically an alias for `/livez`)
+  - Follows Kubernetes ecosystem naming convention
+
+**Implementation:**
+- Expose health endpoints on the same port as metrics or main HTTP server
+- Use context-aware health checks with reasonable timeouts
+- Log health check failures for debugging
+- Keep liveness checks simple to avoid false positives
+- Make readiness checks comprehensive to ensure service quality
+
+**Deployment Configuration:**
+```yaml
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: <service-port>
+  initialDelaySeconds: 15-30
+  periodSeconds: 10-20
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: <service-port>
+  initialDelaySeconds: 5
+  periodSeconds: 5-10
+```
+
+**Backwards Compatibility:**
+- For existing services, maintain old endpoints (`/health`, `/ready`) as aliases
+- Gradually migrate to Kubernetes-standard endpoints
+
 ### Services & Networking
 - Use Services for pod-to-pod communication
 - Prefer ClusterIP for internal services
@@ -470,6 +512,9 @@ When reviewing or suggesting changes, ensure:
 - [ ] K8s resources have proper labels and resource limits
 - [ ] K8s controllers use Patch instead of Update for modifications
 - [ ] Controllers implement graceful shutdown
+- [ ] Health endpoints (/livez, /readyz, /healthz) are implemented for all services
+- [ ] Liveness and readiness probes are configured in deployment YAMLs
+- [ ] Readiness checks verify all critical dependencies (DB, Redis, etc.)
 - [ ] Web UI is accessible and responsive
 - [ ] No unnecessary JavaScript dependencies
 - [ ] Documentation updated (STATUS.md for features, CLAUDE.md for standards, README.md for setup changes)

--- a/deployments/base/api/api.yaml
+++ b/deployments/base/api/api.yaml
@@ -72,13 +72,13 @@ spec:
             cpu: "500m"
         livenessProbe:
           httpGet:
-            path: /health
+            path: /livez
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: /readyz
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/deployments/base/controller/controller-deployment.yaml
+++ b/deployments/base/controller/controller-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /livez
             port: health
           initialDelaySeconds: 15
           periodSeconds: 20

--- a/deployments/base/controller/controller-deployment.yaml
+++ b/deployments/base/controller/controller-deployment.yaml
@@ -33,21 +33,18 @@ spec:
           value: "15s"
         ports:
         - containerPort: 8080
-          name: metrics
-          protocol: TCP
-        - containerPort: 8081
-          name: health
+          name: http
           protocol: TCP
         livenessProbe:
           httpGet:
             path: /livez
-            port: health
+            port: 8080
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
-            port: health
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/deployments/base/controller/controller-service.yaml
+++ b/deployments/base/controller/controller-service.yaml
@@ -8,13 +8,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: metrics
+  - name: http
     port: 8080
-    targetPort: metrics
-    protocol: TCP
-  - name: health
-    port: 8081
-    targetPort: health
+    targetPort: 8080
     protocol: TCP
   selector:
     app: controller

--- a/deployments/base/worker/worker.yaml
+++ b/deployments/base/worker/worker.yaml
@@ -54,6 +54,18 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 9090
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+          initialDelaySeconds: 5
+          periodSeconds: 5
       volumes:
       - name: uploads-storage
         persistentVolumeClaim:

--- a/deployments/base/worker/worker.yaml
+++ b/deployments/base/worker/worker.yaml
@@ -18,7 +18,7 @@ spec:
         component: processor
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"
     spec:
       containers:
@@ -26,8 +26,8 @@ spec:
         image: k8s-learning/worker:latest
         imagePullPolicy: Never
         ports:
-        - name: metrics
-          containerPort: 9090
+        - name: http
+          containerPort: 8080
           protocol: TCP
         env:
         - name: WORKER_ID
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: METRICS_PORT
-          value: "9090"
+          value: "8080"
         envFrom:
         - configMapRef:
             name: app-config
@@ -57,13 +57,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: 9090
+            port: 8080
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 9090
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
       volumes:

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -22,7 +22,8 @@ func NewHealth(repo Repository, queue Queue, log *slog.Logger) *Health {
 	}
 }
 
-func (hh *Health) Health(w http.ResponseWriter, _ *http.Request) {
+// Livez is a basic liveness check - process is running and not deadlocked.
+func (hh *Health) Livez(w http.ResponseWriter, _ *http.Request) {
 	health := map[string]interface{}{
 		"status":    "ok",
 		"timestamp": time.Now().Unix(),
@@ -32,7 +33,8 @@ func (hh *Health) Health(w http.ResponseWriter, _ *http.Request) {
 	hh.writeJSON(w, http.StatusOK, health)
 }
 
-func (hh *Health) Ready(w http.ResponseWriter, r *http.Request) {
+// Readyz checks if the service is ready to accept traffic (dependencies are healthy).
+func (hh *Health) Readyz(w http.ResponseWriter, r *http.Request) {
 	checks := map[string]interface{}{
 		"database": "unknown",
 		"redis":    "unknown",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -80,8 +80,11 @@ func (s *Server) setupRoutes() {
 	jobHandler := handlers.NewJob(s.repo, s.queue, s.fileStore, s.log)
 	healthHandler := handlers.NewHealth(s.repo, s.queue, s.log)
 
-	mux.HandleFunc("GET /health", healthHandler.Health)
-	mux.HandleFunc("GET /ready", healthHandler.Ready)
+	// Kubernetes-style health endpoints
+	mux.HandleFunc("GET /livez", healthHandler.Livez)
+	mux.HandleFunc("GET /readyz", healthHandler.Readyz)
+	mux.HandleFunc("GET /healthz", healthHandler.Livez) // Alias for livez
+
 	mux.HandleFunc("GET /stats", healthHandler.Stats)
 
 	// Prometheus metrics endpoint

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type Worker struct {
 	ConcurrentJobs       int           `envconfig:"CONCURRENT_JOBS" default:"5"`
 	HeartbeatInterval    time.Duration `envconfig:"HEARTBEAT_INTERVAL" default:"30s"`
 	PollInterval         time.Duration `envconfig:"POLL_INTERVAL" default:"5s"`
-	MetricsPort          int           `envconfig:"METRICS_PORT" default:"9090"`
+	MetricsPort          int           `envconfig:"METRICS_PORT" default:"8080"`
 	QueueMetricsInterval time.Duration `envconfig:"QUEUE_METRICS_INTERVAL" default:"15s"`
 }
 


### PR DESCRIPTION
## Summary

Implements standardized Kubernetes health endpoints (`/livez`, `/readyz`, `/healthz`) across all services and consolidates to a single HTTP server per service on port 8080.

## Key Changes

**Health Endpoints:**
- **API**: Added `/livez`, `/readyz`, `/healthz` endpoints (replaced `/health`, `/ready`)
- **Worker**: Added `/livez`, `/readyz`, `/healthz` endpoints (previously had none)
- **Controller**: Added `/livez`, `/healthz` aliases; enhanced `/readyz` to check Redis connectivity

**Port Standardization:**
- All services now use port 8080 for metrics, health, and business logic
- Controller: merged separate servers (metrics:8080, health:8081) → single server on 8080
- Worker: changed default port 9090 → 8080

**Kubernetes Configuration:**
- Updated all deployment YAMLs with liveness and readiness probes
- Worker deployment now includes health probes (previously missing)
- All probes use `/livez` for liveness, `/readyz` for readiness

**Developer Experience:**
- Updated `make k8s-forward` with new port mappings:
  - API: `localhost:8080`
  - Worker: `localhost:8181` → `pod:8080`
  - Controller: `localhost:8282` → `pod:8080`

**Documentation:**
- Added Health Endpoints section to CLAUDE.md with implementation guidelines
- Updated Code Review Checklist with health endpoint requirements
- Updated monitoring commands with new port mappings

## Health Check Behavior

- **`/livez`**: Basic liveness check (process running, no deadlock)
- **`/readyz`**: Dependency checks (database, Redis connectivity)
- **`/healthz`**: Alias for `/livez` (Kubernetes convention)

## Testing

```bash
# Build and verify
make build
make lint

# Deploy to minikube
make k8s-redeploy SERVICE=all

# Test health endpoints via port-forward
make k8s-forward
curl http://localhost:8080/livez    # API
curl http://localhost:8181/readyz   # Worker
curl http://localhost:8282/healthz  # Controller

# Check pod health
kubectl get pods -n k8s-learning
```

## Breaking Changes

- API endpoints `/health` and `/ready` removed (replaced with `/livez`, `/readyz`)
- Deployment YAMLs updated accordingly, no manual intervention needed if deploying from scratch