### PR TITLE
refactor: consolidate queue metrics collection in controller

### DIFF
--- a/deployments/base/monitoring/dashboards/worker-dashboard.json
+++ b/deployments/base/monitoring/dashboards/worker-dashboard.json
@@ -380,7 +380,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "worker_queue_depth",
+          "expr": "textprocessing_queue_depth",
           "legendFormat": "{{queue_name}}",
           "range": true,
           "refId": "A"
@@ -1001,7 +1001,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(worker_queue_depth{queue_name=~\"text_tasks|text_tasks:priority\"})",
+          "expr": "sum(textprocessing_queue_depth{queue_name=~\"text_tasks|text_tasks:priority\"})",
           "range": true,
           "refId": "A"
         }

--- a/deployments/base/monitoring/dashboards/worker-dashboard.json
+++ b/deployments/base/monitoring/dashboards/worker-dashboard.json
@@ -949,129 +949,6 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "success"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 12,
-        "x": 0,
-        "y": 31
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.4.0",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "sum(rate(worker_heartbeats_total[5m])) by (status)",
-          "legendFormat": "{{status}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Heartbeat Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
             "mode": "thresholds"
           },
           "mappings": [],
@@ -1416,13 +1293,13 @@
     "list": []
   },
   "time": {
-    "from": "2025-10-07T13:18:08.321Z",
-    "to": "2025-10-07T13:25:16.597Z"
+    "from": "now-30m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Worker Service Metrics",
   "uid": "worker-service-metrics",
-  "version": 4,
+  "version": 6,
   "weekStart": ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,6 @@ type Worker struct {
 	Logging              Logging
 	WorkerID             string        `envconfig:"WORKER_ID"`
 	ConcurrentJobs       int           `envconfig:"CONCURRENT_JOBS" default:"5"`
-	HeartbeatInterval    time.Duration `envconfig:"HEARTBEAT_INTERVAL" default:"30s"`
 	PollInterval         time.Duration `envconfig:"POLL_INTERVAL" default:"5s"`
 	MetricsPort          int           `envconfig:"METRICS_PORT" default:"8080"`
 	QueueMetricsInterval time.Duration `envconfig:"QUEUE_METRICS_INTERVAL" default:"15s"`
@@ -209,9 +208,6 @@ func (w *Worker) Validate() error {
 	}
 
 	// Interval validation
-	if w.HeartbeatInterval <= 0 {
-		return errors.New("heartbeat interval must be positive")
-	}
 	if w.PollInterval <= 0 {
 		return errors.New("poll interval must be positive")
 	}
@@ -227,14 +223,6 @@ func (w *Worker) Validate() error {
 	// Worker validation
 	if w.ConcurrentJobs <= 0 {
 		return errors.New("concurrent jobs must be positive")
-	}
-
-	if w.HeartbeatInterval <= 0 {
-		return errors.New("heartbeat interval must be positive")
-	}
-
-	if w.PollInterval <= 0 {
-		return errors.New("poll interval must be positive")
 	}
 
 	// SSL mode validation

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,15 +21,14 @@ type API struct {
 }
 
 type Worker struct {
-	Database             Database
-	Redis                Redis
-	Storage              Storage
-	Logging              Logging
-	WorkerID             string        `envconfig:"WORKER_ID"`
-	ConcurrentJobs       int           `envconfig:"CONCURRENT_JOBS" default:"5"`
-	PollInterval         time.Duration `envconfig:"POLL_INTERVAL" default:"5s"`
-	MetricsPort          int           `envconfig:"METRICS_PORT" default:"8080"`
-	QueueMetricsInterval time.Duration `envconfig:"QUEUE_METRICS_INTERVAL" default:"15s"`
+	Database       Database
+	Redis          Redis
+	Storage        Storage
+	Logging        Logging
+	WorkerID       string        `envconfig:"WORKER_ID"`
+	ConcurrentJobs int           `envconfig:"CONCURRENT_JOBS" default:"5"`
+	PollInterval   time.Duration `envconfig:"POLL_INTERVAL" default:"5s"`
+	MetricsPort    int           `envconfig:"METRICS_PORT" default:"8080"`
 }
 
 type Controller struct {
@@ -210,9 +209,6 @@ func (w *Worker) Validate() error {
 	// Interval validation
 	if w.PollInterval <= 0 {
 		return errors.New("poll interval must be positive")
-	}
-	if w.QueueMetricsInterval <= 0 {
-		return errors.New("queue metrics interval must be positive")
 	}
 
 	// Storage validation

--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -20,13 +20,6 @@ var (
 		[]string{"queue_name"},
 	)
 
-	activeWorkersGauge = promauto.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "textprocessing_active_workers",
-			Help: "Number of active text processing workers",
-		},
-	)
-
 	// Scaling metrics.
 	autoscalingEventsCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -103,17 +96,8 @@ func (m *Collector) CollectQueueMetrics(ctx context.Context) error {
 		queueDepthGauge.WithLabelValues(queueName).Set(float64(length))
 	}
 
-	// Get active workers
-	workers, err := m.queue.GetActiveWorkers(ctx)
-	if err != nil {
-		return err
-	}
-
-	activeWorkersGauge.Set(float64(len(workers)))
-
 	m.log.DebugContext(ctx, "collected queue metrics",
-		"queue_lengths", queueLengths,
-		"active_workers", len(workers))
+		"queue_lengths", queueLengths)
 
 	return nil
 }

--- a/internal/worker/interfaces.go
+++ b/internal/worker/interfaces.go
@@ -12,8 +12,6 @@ import (
 type JobConsumer interface {
 	ConsumeJob(ctx context.Context, timeout time.Duration) (*queue.SubmitJobMessage, error)
 	PublishToFailedQueue(ctx context.Context, message queue.SubmitJobMessage, errorMsg string) error
-	GetQueueLength(ctx context.Context, queueName string) (int64, error)
-	GetAllQueuesLength(ctx context.Context) (map[string]int64, error)
 	HealthCheck(ctx context.Context) error
 	Close() error
 }

--- a/internal/worker/interfaces.go
+++ b/internal/worker/interfaces.go
@@ -11,7 +11,6 @@ import (
 
 type JobConsumer interface {
 	ConsumeJob(ctx context.Context, timeout time.Duration) (*queue.SubmitJobMessage, error)
-	SetWorkerHeartbeat(ctx context.Context, workerID string, interval time.Duration) error
 	PublishToFailedQueue(ctx context.Context, message queue.SubmitJobMessage, errorMsg string) error
 	GetQueueLength(ctx context.Context, queueName string) (int64, error)
 	GetAllQueuesLength(ctx context.Context) (map[string]int64, error)

--- a/internal/worker/metrics/metrics.go
+++ b/internal/worker/metrics/metrics.go
@@ -82,15 +82,6 @@ var (
 		[]string{"worker_id", "operation"},
 	)
 
-	// HeartbeatsTotal tracks the total number of heartbeats sent.
-	HeartbeatsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "worker_heartbeats_total",
-			Help: "Total number of heartbeats sent by the worker",
-		},
-		[]string{"worker_id", "status"},
-	)
-
 	// WorkerInfo provides worker metadata as labels.
 	WorkerInfo = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/internal/worker/metrics/metrics.go
+++ b/internal/worker/metrics/metrics.go
@@ -90,13 +90,4 @@ var (
 		},
 		[]string{"worker_id", "version"},
 	)
-
-	// QueueDepth tracks the number of jobs pending in each queue.
-	QueueDepth = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "worker_queue_depth",
-			Help: "Number of jobs pending in the queue",
-		},
-		[]string{"queue_name"},
-	)
 )


### PR DESCRIPTION
## Summary

Refactors metrics collection to consolidate queue depth monitoring in the controller service, removing redundant worker heartbeat system and duplicate queue metrics collection from workers.

## Key Changes

**Controller Metrics Consolidation:**
- Controller now responsible for collecting all queue depth metrics via periodic polling
- Removed `activeWorkersGauge` metric (redundant with Kubernetes replica tracking)
- Simplified `CollectQueueMetrics` to only gather queue depths

**Worker Simplification:**
- Removed custom heartbeat system (`heartbeatLoop`, `SetWorkerHeartbeat`)
- Removed queue metrics collection loop (now handled by controller)
- Removed `HeartbeatsTotal` and `QueueDepth` metrics from worker
- Cleaned up unused config fields: `HeartbeatInterval`, `QueueMetricsInterval`

**Redis Queue Cleanup:**
- Removed worker heartbeat tracking methods: `SetWorkerHeartbeat`, `GetActiveWorkers`, `CleanupStaleWorkers`
- Simplified stats endpoint to only return queue lengths
- Removed heartbeat-related constants

**Scaler Updates:**
- Removed `ActiveWorkers` field from `QueueStats` struct
- Scaling decisions now based purely on queue depth (existing behavior)

**Dashboard Updates:**
- Removed worker-reported queue depth panels from worker dashboard (now reported by controller)

## Rationale

- **Single source of truth:** Controller monitors queues centrally instead of each worker duplicating this work
- **Simpler worker lifecycle:** Workers focus only on job processing, no heartbeat management
- **Kubernetes-native:** Use K8s pod readiness/liveness instead of custom heartbeat system
- **Reduced Redis load:** Fewer operations per worker, no heartbeat key churn

## Testing

```bash
# Verify controller collects metrics
kubectl port-forward -n k8s-learning deployment/controller 8282:8080
curl http://localhost:8282/metrics | grep textprocessing_queue_depth

# Verify autoscaling still works
make run-stress-test
kubectl get pods -n k8s-learning -w  # Watch worker scaling

# Check worker dashboard still works
make k8s-forward
# Open http://localhost:3000 - Worker dashboard should show job metrics
```

## Related
- Part of monitoring improvements from #10, #12, #15
- Simplifies architecture by removing custom distributed monitoring
